### PR TITLE
Type checking on experiments name & get_experiment_names

### DIFF
--- a/client/python/README.md
+++ b/client/python/README.md
@@ -58,7 +58,7 @@ bar = cc.create_experiment("bar", zip_file=filename)
 bar.get_scalar_names()
 #>> ["accuracy"]
 
-# Get the datas for this experiment
+# Get the data for this experiment
 foo.get_scalar_values("accuracy")
 #>> [[11.3, 0, 0.0], [12.3, 1, 4.0], [13.3, 4, 6.0]])
 ```
@@ -70,7 +70,7 @@ foo.get_scalar_values("accuracy")
 * Creation: `CrayonClient(hostname="localhost", port=8889)`
   * Create a client object and connect it to the server at address `hostname` and port `port`.
 
-* `get_experiment_list()`
+* `get_experiment_names()`
   * Returns a list of string containing the name of all the experiments on the server.
 
 * `create_experiment(xp_name, zip_file=None)`
@@ -78,11 +78,15 @@ foo.get_scalar_values("accuracy")
   * If `zip_file` is provided, this experiment is initialized with the content of the zip file (see `CrayonExperiment.to_zip` to get the zip file).
 
 * `open_experiment(xp_name)`
-  * Opens the experiment called `xp_name` that already exist on the server.
+  * Opens the experiment called `xp_name` that already exists on the server.
 
 * `remove_experiment(xp_name)`
   * Removes the experiment `xp_name` from the server.
-  * WARNING: all the elements in this experiment are definitively lost!
+  * WARNING: all elements from this experiment are permanently lost!
+
+* `remove_all_experiments()`
+  * Removes all experiment from the server.
+  * WARNING: all elements from all experiments are permanently lost!
 
 
 ### `CrayonExperiment`
@@ -102,7 +106,7 @@ foo.get_scalar_values("accuracy")
 
 * `get_scalar_values(name)`
   * Return a list with one entry for each point added for this scalar plot.
-  * Each entry is a list containing [wall_time, step, value]. 
+  * Each entry is a list containing [wall_time, step, value].
 
 * `get_histogram_names()`
   * Returns a list of string containing the name of all the histogram values in this experiment.

--- a/client/python/pycrayon/crayon.py
+++ b/client/python/pycrayon/crayon.py
@@ -5,6 +5,10 @@ import collections
 
 __version__ = "0.3"
 
+try:
+  basestring
+except NameError:
+  basestring = str
 
 class CrayonClient(object):
 
@@ -33,7 +37,7 @@ class CrayonClient(object):
                                                           self.port) +
                              " does not appear to be up!")
 
-    def get_experiment_list(self):
+    def get_experiment_names(self):
         query = "/data"
         r = requests.get(self.url + query)
         if not r.ok:
@@ -43,19 +47,24 @@ class CrayonClient(object):
         return experiments
 
     def open_experiment(self, xp_name):
-        assert(isinstance(xp_name, str))
+        assert(isinstance(xp_name, basestring))
         return CrayonExperiment(xp_name, self, create=False)
 
     def create_experiment(self, xp_name, zip_file=None):
-        assert(isinstance(xp_name, str))
+        assert(isinstance(xp_name, basestring))
         return CrayonExperiment(xp_name, self, zip_file=zip_file, create=True)
 
     def remove_experiment(self, xp_name):
-        assert(isinstance(xp_name, str))
+        assert(isinstance(xp_name, basestring))
         query = "/data?xp={}".format(xp_name)
         r = requests.delete(self.url + query)
         if not r.ok:
             raise ValueError("Something went wrong. Server sent: {}.".format(r.text))
+
+    def remove_all_experiments(self):
+        xp_list = self.get_experiment_names()
+        for xp_name in xp_list:
+            self.remove_experiment(xp_name)
 
 class CrayonExperiment(object):
 
@@ -124,7 +133,7 @@ class CrayonExperiment(object):
 
     def add_scalar_dict(self, data, wall_time=-1, step=-1):
         for name, value in data.iteritems():
-            if not isinstance(name, str):
+            if not isinstance(name, basestring):
                 msg = "Scalar name should be a string, got: {}.".format(name)
                 raise ValueError(msg)
             self.add_scalar_value(name, value, wall_time, step)

--- a/server/server.py
+++ b/server/server.py
@@ -33,6 +33,13 @@ from subprocess import Popen, PIPE
 from flask import send_file
 import shutil
 
+def to_unicode(experiment):
+
+  assert isinstance(experiment, basestring)
+
+  return unicode(experiment)
+
+
 ### Tensorboard utility functions
 tensorboard_folder = "/tmp/tensorboard/{}"
 # Make sure we do not access data too fast
@@ -70,7 +77,7 @@ def tb_remove_xp_writer(experiment):
   if experiment in xp_writers:
     del xp_writers[experiment]
     # Prevent recreating it too quickly
-    tb_access_xp(experiment)
+    tb_modified_xp(experiment)
 
 def tb_xp_writer_exists(experiment):
   return experiment in xp_writers
@@ -166,8 +173,10 @@ def wrong_argument(message):
 def get_version():
   # Verify that tensorboard is running
   req_res = tb_request("logdir")
-  if not isinstance(req_res, str):
-    return req_res
+  try:
+    req_res = to_unicode(req_res)
+  except TypeError:
+    return wrong_argument("'logdir' should be of type string or unicode instead of '{}'".format(type(req_res)))
 
   if not json.loads(req_res)["logdir"] == tensorboard_folder[:-3]:
     return wrong_argument("Tensorboard is not running in the correct folder.")
@@ -179,6 +188,10 @@ def get_version():
 @app.route('/data', methods=["GET"])
 def get_all_experiments():
   experiment = request.args.get('xp')
+  try:
+    experiment = to_unicode(experiment)
+  except TypeError:
+    return wrong_argument("Experiment name should be of type string or unicode instead of '{}'".format(type(experiment)))
 
   result = ""
   req_res = tb_request("runs")
@@ -206,9 +219,11 @@ def get_all_experiments():
 
 @app.route('/data', methods=["POST"])
 def post_experiment():
-  experiment = str(request.get_json()) # Is unicode otherwise
-  if not experiment:
-    return wrong_argument("post content is not a string but '{}'".format(type(experiment)))
+  experiment = request.get_json()
+  try:
+    experiment = to_unicode(experiment)
+  except TypeError:
+    return wrong_argument("Experiment name should be of type string or unicode instead of '{}'".format(type(experiment)))
 
   if tb_xp_writer_exists(experiment):
     return wrong_argument("'{}' experiment already exists".format(experiment))
@@ -219,6 +234,10 @@ def post_experiment():
 @app.route('/data', methods=["DELETE"])
 def delete_experiment():
   experiment = request.args.get('xp')
+  try:
+    experiment = to_unicode(experiment)
+  except TypeError:
+    return wrong_argument("Experiment name should be of type string or unicode instead of '{}'".format(type(experiment)))
 
   if not tb_xp_writer_exists(experiment):
     return wrong_argument("'{}' experiment does not already exists".format(experiment))
@@ -236,6 +255,10 @@ def delete_experiment():
 @app.route('/data/scalars', methods=["GET"])
 def get_scalars():
   experiment = request.args.get('xp')
+  try:
+    experiment = to_unicode(experiment)
+  except TypeError:
+    return wrong_argument("Experiment name should be of type string or unicode instead of '{}'".format(type(experiment)))
   name = request.args.get('name')
   if (not experiment) or (not name):
     return wrong_argument("xp and name arguments are required")
@@ -247,6 +270,10 @@ def get_scalars():
 @app.route('/data/scalars', methods=['POST'])
 def post_scalars():
   experiment = request.args.get('xp')
+  try:
+    experiment = to_unicode(experiment)
+  except TypeError:
+    return wrong_argument("Experiment name should be of type string or unicode instead of '{}'".format(type(experiment)))
   name = request.args.get('name')
   if (not experiment) or (not name):
     return wrong_argument("xp and name arguments are required")
@@ -272,6 +299,10 @@ def post_scalars():
 @app.route('/data/histograms', methods=["GET"])
 def get_histograms():
   experiment = request.args.get('xp')
+  try:
+    experiment = to_unicode(experiment)
+  except TypeError:
+    return wrong_argument("Experiment name should be of type string or unicode instead of '{}'".format(type(experiment)))
   name = request.args.get('name')
   if (not experiment) or (not name):
     return wrong_argument("xp and name arguments are required")
@@ -283,6 +314,10 @@ def get_histograms():
 @app.route('/data/histograms', methods=['POST'])
 def post_histograms():
   experiment = request.args.get('xp')
+  try:
+    experiment = to_unicode(experiment)
+  except TypeError:
+    return wrong_argument("Experiment name should be of type string or unicode instead of '{}'".format(type(experiment)))
   name = request.args.get('name')
   to_build = request.args.get('tobuild')
   if (not experiment) or (not name) or (not to_build):
@@ -335,6 +370,10 @@ def post_histograms():
 @app.route('/backup', methods=['GET'])
 def get_backup():
   experiment = request.args.get('xp')
+  try:
+    experiment = to_unicode(experiment)
+  except TypeError:
+    return wrong_argument("Experiment name should be of type string or unicode instead of '{}'".format(type(experiment)))
   if not experiment:
     return wrong_argument("xp argument is required")
 
@@ -350,6 +389,10 @@ def get_backup():
 @app.route('/backup', methods=['POST'])
 def post_backup():
   experiment = request.args.get('xp')
+  try:
+    experiment = to_unicode(experiment)
+  except TypeError:
+    return wrong_argument("Experiment name should be of type string or unicode instead of '{}'".format(type(experiment)))
   force = request.args.get('force')
   if (not experiment) or (not force):
     return wrong_argument("xp and force argument are required")

--- a/server/server.py
+++ b/server/server.py
@@ -35,7 +35,7 @@ import shutil
 
 def to_unicode(experiment):
 
-  assert isinstance(experiment, basestring)
+  assert isinstance(experiment, basestring) and experiment
 
   return unicode(experiment)
 

--- a/server/server.py
+++ b/server/server.py
@@ -186,10 +186,6 @@ def get_version():
 @app.route('/data', methods=["GET"])
 def get_all_experiments():
   experiment = request.args.get('xp')
-  try:
-    experiment = to_unicode(experiment)
-  except TypeError:
-    return wrong_argument("Experiment name should be of type string or unicode instead of '{}'".format(type(experiment)))
 
   result = ""
   try:
@@ -199,6 +195,10 @@ def get_all_experiments():
 
   tb_data = json.loads(req_res)
   if experiment:
+    try:
+      experiment = to_unicode(experiment)
+    except TypeError:
+      return wrong_argument("Experiment name should be of type string or unicode instead of '{}'".format(type(experiment)))
     if not tb_xp_writer_exists(experiment):
       return wrong_argument("Unknown experiment name '{}'".format(experiment))
     if experiment in tb_data:


### PR DESCRIPTION
- Test  type of experiment name for unicode / string on client side, always convert compatible types to unicode on server side
- Changed `get_experiment_list` to `get_experiment_names`
- Added `remove_all experiments` function