### PR TITLE
Make python client pip-installable.

### DIFF
--- a/client/python/MANIFEST
+++ b/client/python/MANIFEST
@@ -2,4 +2,5 @@
 setup.py
 pycrayon/__init__.py
 pycrayon/crayon.py
+pycrayon/version.py
 test/test_crayon.py

--- a/client/python/pycrayon/crayon.py
+++ b/client/python/pycrayon/crayon.py
@@ -3,7 +3,7 @@ import json
 import time
 import collections
 
-__version__ = "0.5"
+from .version import __version__
 
 try:
     basestring

--- a/client/python/pycrayon/version.py
+++ b/client/python/pycrayon/version.py
@@ -1,0 +1,8 @@
+r"""
+Little utility to reveal the package version.
+Place in the root dir of the package.
+"""
+from pkg_resources import get_distribution
+
+
+__version__ = get_distribution(__name__.split('.')[0]).version

--- a/client/python/setup.py
+++ b/client/python/setup.py
@@ -1,12 +1,11 @@
-from distutils.core import setup
-from pycrayon.crayon import __version__
+from setuptools import setup
 
 setup(name='pycrayon',
       description='Crayon client for python',
       author='torrvision',
       url='https://github.com/torrvision/crayon',
       packages=['pycrayon'],
-      version=__version__,
+      version='0.5',
       install_requires=[
         "requests"
       ]

--- a/client/python/test/test_crayon.py
+++ b/client/python/test/test_crayon.py
@@ -2,8 +2,8 @@ import unittest
 import time
 import os
 
-from .helper import Helper
-from pycrayon.crayon import CrayonClient
+from pycrayon import CrayonClient
+from helper import Helper
 
 
 class CrayonClientTestSuite(unittest.TestCase):


### PR DESCRIPTION
- The `client` is now `pip-installable` even if `requests` is not present in the environment.
- Closes #24 